### PR TITLE
Refactor feature transformer to use data loader

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,3 @@
+from .loaders import SQLiteDataLoader
+
+__all__ = ["SQLiteDataLoader"]

--- a/src/data/loaders/__init__.py
+++ b/src/data/loaders/__init__.py
@@ -1,0 +1,3 @@
+from .sqlite_loader import SQLiteDataLoader
+
+__all__ = ["SQLiteDataLoader"]

--- a/src/data/loaders/sqlite_loader.py
+++ b/src/data/loaders/sqlite_loader.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pandas as pd
+
+from ..handlers.sqlite_handler import SQLiteHandler
+
+
+class SQLiteDataLoader:
+    """Load data from SQLite database."""
+
+    def load_columns(self, db_path: Path, table_name: str, columns: list[str]) -> pd.DataFrame:
+        """Return selected columns as DataFrame."""
+        handler = SQLiteHandler(db_path)
+        quoted = [f'"{c}"' for c in columns]
+        query = f"SELECT {', '.join(quoted)} FROM {table_name}"
+        try:
+            results = handler.fetch_all(query)
+            if not results:
+                return pd.DataFrame()
+            return pd.DataFrame(results, columns=columns)
+        except Exception as e:  # pragma: no cover - simple print fallback
+            print(f"❌ データ読み込みエラー: {e}")
+            return pd.DataFrame()


### PR DESCRIPTION
## Summary
- introduce `SQLiteDataLoader` for SQLite table loading
- export loader from `src.data`
- update `FeatureTransformer` to delegate database access to loader

## Testing
- `ruff format src/data/loaders/sqlite_loader.py src/data/loaders/__init__.py src/data/__init__.py src/module/feature_transformer.py`
- `ruff check src/data/loaders/sqlite_loader.py src/data/loaders/__init__.py src/data/__init__.py src/module/feature_transformer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685cd7fd5cc483239ef38619685feaa4