### PR TITLE
Add nested CV and hyper tuning modules

### DIFF
--- a/src/ml/__init__.py
+++ b/src/ml/__init__.py
@@ -1,0 +1,12 @@
+from .nested_cv import nested_cv_evaluate
+from .hyper_tuner import HyperTuner
+from .managers import FeatureManager, TargetManager
+from .pipeline import TreeModelPipeline
+
+__all__ = [
+    "nested_cv_evaluate",
+    "HyperTuner",
+    "FeatureManager",
+    "TargetManager",
+    "TreeModelPipeline",
+]

--- a/src/ml/hyper_tuner.py
+++ b/src/ml/hyper_tuner.py
@@ -1,0 +1,39 @@
+from typing import Any, Callable, Dict, List
+
+import pandas as pd
+
+from .nested_cv import nested_cv_evaluate
+
+
+class HyperTuner:
+    """ネスト化クロスバリデーションを用いたハイパーパラメータチューニングクラス"""
+
+    def __init__(
+        self,
+        estimator_factory: Callable[[], Any],
+        param_grid: Dict[str, List[Any]],
+        outer_splits: int = 5,
+        inner_splits: int = 3,
+        scoring: str = "r2",
+    ) -> None:
+        self.estimator_factory = estimator_factory
+        self.param_grid = param_grid
+        self.outer_splits = outer_splits
+        self.inner_splits = inner_splits
+        self.scoring = scoring
+
+    def tune(self, X: pd.DataFrame, y: pd.Series) -> Dict[str, Any]:
+        """ネストCVにより最適パラメータを探索し、平均スコアを返す"""
+        print(f"🔄 Nested CV ({self.outer_splits}×{self.inner_splits}) でチューニング中...")
+        scores, best_params = nested_cv_evaluate(
+            estimator_factory=self.estimator_factory,
+            param_grid=self.param_grid,
+            X=X,
+            y=y,
+            outer_splits=self.outer_splits,
+            inner_splits=self.inner_splits,
+            scoring=self.scoring,
+        )
+        avg_score = sum(scores) / len(scores)
+        print(f"🔧 平均スコア ({self.scoring}): {avg_score:.4f}")
+        return {"best_params": best_params[0], "avg_score": avg_score}

--- a/src/ml/managers.py
+++ b/src/ml/managers.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pandas as pd
+
+
+@dataclass
+class FeatureManager:
+    """シンプルな特徴量管理クラス"""
+
+    features: pd.DataFrame | None = None
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        self.features = df.copy()
+        return self.features
+
+
+@dataclass
+class TargetManager:
+    """シンプルなターゲット管理クラス"""
+
+    target: pd.Series | None = None
+
+    def transform(self, series: pd.Series) -> pd.Series:
+        self.target = series.copy()
+        return self.target

--- a/src/ml/nested_cv.py
+++ b/src/ml/nested_cv.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable, Dict, List, Tuple
+
+import pandas as pd
+from sklearn.model_selection import GridSearchCV, KFold
+
+
+def nested_cv_evaluate(
+    estimator_factory: Callable[[], Any],
+    param_grid: Dict[str, List[Any]],
+    X: pd.DataFrame,
+    y: pd.Series,
+    outer_splits: int = 5,
+    inner_splits: int = 3,
+    scoring: str = "r2",
+) -> Tuple[List[float], List[Dict[str, Any]]]:
+    """外側CVと内側CVを組み合わせた評価関数"""
+    outer_cv = KFold(n_splits=outer_splits, shuffle=True, random_state=42)
+    test_scores: List[float] = []
+    best_params_list: List[Dict[str, Any]] = []
+
+    for train_idx, test_idx in outer_cv.split(X):
+        X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+        y_train, y_test = y.iloc[train_idx], y.iloc[test_idx]
+
+        inner_cv = KFold(n_splits=inner_splits, shuffle=True, random_state=42)
+        grid = GridSearchCV(
+            estimator=estimator_factory(),
+            param_grid=param_grid,
+            cv=inner_cv,
+            scoring=scoring,
+            n_jobs=-1,
+        )
+        grid.fit(X_train, y_train)
+
+        best_model = grid.best_estimator_
+        score = best_model.score(X_test, y_test)
+
+        test_scores.append(score)
+        best_params_list.append(grid.best_params_)
+
+    return test_scores, best_params_list

--- a/src/ml/pipeline.py
+++ b/src/ml/pipeline.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sklearn.model_selection import train_test_split
+
+from .managers import FeatureManager, TargetManager
+
+
+class TreeModelPipeline:
+    """シンプルな学習用パイプライン"""
+
+    def __init__(self, model: Any, feature_manager: FeatureManager, target_manager: TargetManager) -> None:
+        self.model = model
+        self.feature_manager = feature_manager
+        self.target_manager = target_manager
+
+    def train(self, test_size: float = 0.2, random_state: int = 42) -> dict[str, float]:
+        if self.feature_manager.features is None or self.target_manager.target is None:
+            raise ValueError("特徴量またはターゲットが設定されていません")
+        X = self.feature_manager.features
+        y = self.target_manager.target
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, random_state=random_state)
+        self.model.fit(X_train, y_train)
+        train_r2 = self.model.score(X_train, y_train)
+        test_r2 = self.model.score(X_test, y_test)
+        return {"train_r2": float(train_r2), "test_r2": float(test_r2)}

--- a/src/scripts/08_hyper_tuning.py
+++ b/src/scripts/08_hyper_tuning.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import sys
+
+import pandas as pd
+from lightgbm import LGBMRegressor
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.ml import FeatureManager, HyperTuner, TargetManager
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-path", type=str, required=True)
+    parser.add_argument("--target-column", type=str, required=True)
+    parser.add_argument("--outer-splits", type=int, default=5)
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data_path)
+
+    feature_manager = FeatureManager()
+    target_manager = TargetManager()
+    X = feature_manager.transform(df.drop(columns=[args.target_column]))
+    y = target_manager.transform(df[args.target_column])
+
+    estimator_factory = lambda: LGBMRegressor()
+    param_grid = {"n_estimators": [100, 200], "max_depth": [5, 10]}
+
+    tuner = HyperTuner(
+        estimator_factory=estimator_factory,
+        param_grid=param_grid,
+        outer_splits=args.outer_splits,
+        inner_splits=3,
+    )
+    result = tuner.tune(X, y)
+    print(f"最適パラメータ: {result['best_params']}")
+    print(f"平均スコア: {result['avg_score']:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/12_model_test.py
+++ b/src/scripts/12_model_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import sys
+
+import pandas as pd
+from lightgbm import LGBMRegressor
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.ml import FeatureManager, HyperTuner, TargetManager, TreeModelPipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-path", type=str, required=True)
+    parser.add_argument("--target-column", type=str, required=True)
+    parser.add_argument("--outer-splits", type=int, default=5)
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data_path)
+
+    feature_manager = FeatureManager()
+    target_manager = TargetManager()
+    X = feature_manager.transform(df.drop(columns=[args.target_column]))
+    y = target_manager.transform(df[args.target_column])
+
+    estimator_factory = lambda: LGBMRegressor()
+    param_grid = {"n_estimators": [100, 200], "max_depth": [5, 10]}
+    tuner = HyperTuner(estimator_factory, param_grid, outer_splits=args.outer_splits, inner_splits=3)
+    tune_result = tuner.tune(X, y)
+
+    best_params = tune_result["best_params"]
+    model = LGBMRegressor(**best_params)
+    pipeline = TreeModelPipeline(model=model, feature_manager=feature_manager, target_manager=target_manager)
+    results = pipeline.train(test_size=0.1, random_state=42)
+    print(f"最終モデルテストR²: {results['test_r2']:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/ml` package with simple data managers, pipeline, nested CV, and hyperparameter tuner
- provide example scripts `08_hyper_tuning.py` and `12_model_test.py` demonstrating usage

## Testing
- `ruff check src/ml/nested_cv.py src/ml/hyper_tuner.py src/ml/managers.py src/ml/pipeline.py src/ml/__init__.py src/scripts/08_hyper_tuning.py src/scripts/12_model_test.py`
- `pytest -q` *(fails: ModuleNotFoundError for numpy and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685e163bc78483239652e61c0549abae